### PR TITLE
Simplify file handler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,8 @@ add_library(${PROJECT_NAME}
     src/ez/http/HttpRequestHandler.h
     src/ez/http/HttpServer.h
     src/ez/http/HttpServer.cpp
+    src/ez/http/HttpSingleFileHandler.h
+    src/ez/http/HttpSingleFileHandler.cpp
     src/ez/http/HttpStatus.h
     src/ez/http/HttpWebSocketHandler.h
     src/ez/http/HttpWebSocketParser.h

--- a/conanfile.py
+++ b/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class EzHttpConan(ConanFile):
     name = "ez-http"
-    version = "0.2.1"
+    version = "0.2.2"
     ZIP_FOLDER_NAME = "%s-%s" % (name, version)
     url = "https://github.com/0x7f/ez-http"
     license = "https://github.com/0x7f/ez-http/blob/master/LICENSE"

--- a/src/ez/http/HttpFileHandler.h
+++ b/src/ez/http/HttpFileHandler.h
@@ -2,6 +2,8 @@
 
 #include <string>
 
+#include <boost/optional.hpp>
+
 #include "ez/http/HttpRequestHandler.h"
 
 namespace ez {
@@ -14,13 +16,13 @@ class HttpFileHandler : public HttpRequestHandler {
     virtual bool handleRequest(const HttpRequest &req,
                                HttpResponse &res) override;
 
-    bool setFileNotFoundPage(const std::string &errorPath);
+  protected:
+    virtual boost::optional<std::string> resolve_path(const std::string &);
 
   private:
     std::string determine_mime_type(const std::string &extension);
 
     std::string root_;
-    std::string errorPage_;
 };
 
 } // namespace http

--- a/src/ez/http/HttpSingleFileHandler.cpp
+++ b/src/ez/http/HttpSingleFileHandler.cpp
@@ -1,0 +1,15 @@
+#include "ez/http/HttpSingleFileHandler.h"
+
+namespace ez {
+namespace http {
+
+HttpSingleFileHandler::HttpSingleFileHandler(const std::string &file)
+    : HttpFileHandler("."), file_(file) {}
+
+boost::optional<std::string>
+HttpSingleFileHandler::resolve_path(const std::string &) {
+    return file_;
+}
+
+} // namespace http
+} // namespace ez

--- a/src/ez/http/HttpSingleFileHandler.h
+++ b/src/ez/http/HttpSingleFileHandler.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <string>
+
+#include "ez/http/HttpFileHandler.h"
+
+namespace ez {
+namespace http {
+
+class HttpSingleFileHandler : public HttpFileHandler {
+  public:
+    explicit HttpSingleFileHandler(const std::string &file);
+
+  protected:
+    virtual boost::optional<std::string>
+    resolve_path(const std::string &) override;
+
+    std::string file_;
+};
+
+} // namespace http
+} // namespace ez


### PR DESCRIPTION
Now, the `HttpFileHandler` just falls through if the requested file was not found. Allows executing other handlers to handle that case, e.g. the new `HttpSingleFileHandler` that always serves the same file no matter which url was requested. This is especially useful for React apps where all routes are handled by `index.html`.